### PR TITLE
Fix mobile navbar depths (z-indexes)

### DIFF
--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -37,6 +37,11 @@ html, body {
   .sidebar {
     background-color: $sidebarBg;
     z-index: 100;
+
+    &-mask {
+      background-color: $sidebarBg;
+      opacity: 0.85;
+    }
   }
 
   .content__default {

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -28,6 +28,7 @@ html, body {
     border: none;
     position: sticky;
     top: 0;
+    z-index: 200;
     .links {
       background-color: transparent;
     }
@@ -35,6 +36,7 @@ html, body {
 
   .sidebar {
     background-color: $sidebarBg;
+    z-index: 100;
   }
 
   .content__default {
@@ -215,10 +217,10 @@ blockquote {
   bottom: 0;
   left: 0;
   right: 0;
+  z-index: 0;
 }
 .mojs-interactive__controller .controller {
   position: absolute
-  z-index:2
 }
 .mojs-interactive__clicknotice {
   font-size: 0.85em

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -28,7 +28,6 @@ html, body {
     border: none;
     position: sticky;
     top: 0;
-    z-index: 2;
     .links {
       background-color: transparent;
     }
@@ -36,7 +35,6 @@ html, body {
 
   .sidebar {
     background-color: $sidebarBg;
-    z-index: 1;
   }
 
   .content__default {
@@ -220,6 +218,7 @@ blockquote {
 }
 .mojs-interactive__controller .controller {
   position: absolute
+  z-index:2
 }
 .mojs-interactive__clicknotice {
   font-size: 0.85em


### PR DESCRIPTION
# Summary

Solve the following issues with the navbar:
 - Impossible to click links on mobile sidebar: side mask would overlay on top of the whole app; if you clicked/touch anywhere on the screen it would hit `.sidebar-mask` and toggle the sidebar off.
 - Z-index issues on the sidebar, navbar and video player controls: the video player controls was displayed on top of the sidebar/navbar (had a z-index of 100)

# Previously
<img width="363" alt="Screen Shot 2022-01-22 at 07 24 50" src="https://user-images.githubusercontent.com/17796338/150602063-374f1179-f2a0-4f0d-8afd-d40d95d03c9d.png">
 
# Now
<img width="349" alt="Screen Shot 2022-01-22 at 07 23 54" src="https://user-images.githubusercontent.com/17796338/150602354-d133b6e7-957f-4626-bbef-5c376ce7e273.png">


<img width="344" alt="Screen Shot 2022-01-22 at 07 23 50" src="https://user-images.githubusercontent.com/17796338/150602350-3ba5307b-7601-4c23-9396-c23218f7ad07.png">
