### PR TITLE
Fix link to Shapes & ShapeSwirl

### DIFF
--- a/docs/tutorials/burst/README.md
+++ b/docs/tutorials/burst/README.md
@@ -4,7 +4,7 @@
 Burst is the module that helps you to craft numerous sophisticated motion effects.
 - [API reference](/api/burst)
 
-> Please make sure you are comfortable with [Shapes & ShapeSwirl](/tutorials//shape-swirl/) before proceeding with this tutorial. Understanding those modules is crucial for understanding the `Burst`.
+> Please make sure you are comfortable with [Shapes & ShapeSwirl](/tutorials/shape-swirl/) before proceeding with this tutorial. Understanding those modules is crucial for understanding the `Burst`.
 
 ## Burst
 


### PR DESCRIPTION
Just ran into a broken link on https://mojs.github.io/tutorials/burst/